### PR TITLE
Store entry and client together in hass.data

### DIFF
--- a/custom_components/openai_gpt4o_tts/__init__.py
+++ b/custom_components/openai_gpt4o_tts/__init__.py
@@ -11,11 +11,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up GPT-4o TTS from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Store the config entry so it persists
-    hass.data[DOMAIN][entry.entry_id] = entry
-
-    # Initialize the GPT-4o TTS client
-    hass.data[DOMAIN][entry.entry_id] = GPT4oClient(hass, entry)
+    # Store both the entry and client for easy retrieval later
+    hass.data[DOMAIN][entry.entry_id] = {
+        "entry": entry,
+        "client": GPT4oClient(hass, entry),
+    }
 
     # Forward to TTS platform so HA creates 'tts.openai_gpt4o_tts_say'
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/openai_gpt4o_tts/tts.py
+++ b/custom_components/openai_gpt4o_tts/tts.py
@@ -23,7 +23,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up GPT‑4o TTS from a config entry."""
-    client = hass.data[DOMAIN][config_entry.entry_id]
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    client = data["client"]
     async_add_entities([OpenAIGPT4oTTSProvider(config_entry, client)])
 
 


### PR DESCRIPTION
## Summary
- store both the config entry and the client under `hass.data[DOMAIN][entry_id]`
- update TTS setup to pull client from the stored data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8` *(fails: E302, E501, E231)*

------
https://chatgpt.com/codex/tasks/task_e_687de21527688331a87b7d4897edaf99