### PR TITLE
Add speed option to GPT-4o TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With **11 built-in voices**, you can customise **how speech is rendered** to mat
 ✅ **Uses GPT-4o Mini TTS**, OpenAI’s latest speech model  
 ✅ **Fully UI-based setup**—no YAML required  
 ✅ **11 voices** (`alloy`, `ash`, `ballad`, `coral`, `echo`, etc.)  
-✅ **Customisable speech**—affect, tone, pronunciation, pauses, emotion  
+✅ **Customisable speech**—affect, tone, pronunciation, pauses, emotion, speed
 ✅ **Works with Home Assistant’s Assist**  
 ✅ **Easily installable via HACS**  
 
@@ -68,9 +68,10 @@ Since this is a **custom repository**, you must add it manually:
 - **Affect/Personality** (e.g., "A cheerful guide")  
 - **Tone** (e.g., "Friendly, clear, and reassuring")  
 - **Pronunciation** (e.g., "Clear, articulate, and steady")  
-- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")  
-- **Emotion** (e.g., "Warm and supportive")  
-6. Click **Submit**. 🎉 Done!  
+- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")
+- **Emotion** (e.g., "Warm and supportive")
+- **Speed** (0.25–4.0, where 1.0 is normal)
+6. Click **Submit**. 🎉 Done!
 
 ![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)
 

--- a/custom_components/openai_gpt4o_tts/README.md
+++ b/custom_components/openai_gpt4o_tts/README.md
@@ -25,7 +25,7 @@ With **11 built-in voices**, you can customise **how speech is rendered** to mat
 ✅ **Uses GPT-4o Mini TTS**, OpenAI’s latest speech model  
 ✅ **Fully UI-based setup**—no YAML required  
 ✅ **11 voices** (`alloy`, `ash`, `ballad`, `coral`, `echo`, etc.)  
-✅ **Customisable speech**—affect, tone, pronunciation, pauses, emotion  
+✅ **Customisable speech**—affect, tone, pronunciation, pauses, emotion, speed
 ✅ **Works with Home Assistant’s Assist**  
 ✅ **Easily installable via HACS**  
 
@@ -68,9 +68,10 @@ Since this is a **custom repository**, you must add it manually:
 - **Affect/Personality** (e.g., "A cheerful guide")  
 - **Tone** (e.g., "Friendly, clear, and reassuring")  
 - **Pronunciation** (e.g., "Clear, articulate, and steady")  
-- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")  
-- **Emotion** (e.g., "Warm and supportive")  
-6. Click **Submit**. 🎉 Done!  
+- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")
+- **Emotion** (e.g., "Warm and supportive")
+- **Speed** (0.25–4.0, where 1.0 is normal)
+6. Click **Submit**. 🎉 Done!
 
 ![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)
 

--- a/custom_components/openai_gpt4o_tts/config_flow.py
+++ b/custom_components/openai_gpt4o_tts/config_flow.py
@@ -12,6 +12,8 @@ from .const import (
     CONF_LANGUAGE,
     DEFAULT_VOICE,
     DEFAULT_LANGUAGE,
+    CONF_SPEED,
+    DEFAULT_SPEED,
     DEFAULT_AFFECT,
     DEFAULT_TONE,
     DEFAULT_PRONUNCIATION,
@@ -61,6 +63,7 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             options = {
                 CONF_VOICE: user_input.get(CONF_VOICE, DEFAULT_VOICE),
                 CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
+                CONF_SPEED: user_input.get(CONF_SPEED, DEFAULT_SPEED),
                 CONF_INSTRUCTIONS: user_input.get(CONF_INSTRUCTIONS, ""),
                 "affect_personality": affect,
                 "tone": tone,
@@ -77,6 +80,9 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_API_KEY): str,
             vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(OPENAI_TTS_VOICES),
             vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(SUPPORTED_LANGUAGES),
+            vol.Optional(CONF_SPEED, default=DEFAULT_SPEED): vol.All(
+                vol.Coerce(float), vol.Range(min=0.25, max=4.0)
+            ),
             vol.Optional("affect_personality", default=DEFAULT_AFFECT): vol.All(str, vol.Length(min=5, max=500)),
             vol.Optional("tone", default=DEFAULT_TONE): vol.All(str, vol.Length(min=5, max=500)),
             vol.Optional("pronunciation", default=DEFAULT_PRONUNCIATION): vol.All(str, vol.Length(min=5, max=500)),
@@ -113,6 +119,9 @@ class OpenAIGPT4oOptionsFlowHandler(config_entries.OptionsFlow):
         data_schema = vol.Schema({
             vol.Optional(CONF_VOICE, default=existing.get(CONF_VOICE, DEFAULT_VOICE)): vol.In(OPENAI_TTS_VOICES),
             vol.Optional(CONF_LANGUAGE, default=existing.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)): vol.In(SUPPORTED_LANGUAGES),
+            vol.Optional(CONF_SPEED, default=existing.get(CONF_SPEED, DEFAULT_SPEED)): vol.All(
+                vol.Coerce(float), vol.Range(min=0.25, max=4.0)
+            ),
             vol.Optional("affect_personality", default=existing.get("affect_personality", DEFAULT_AFFECT)): vol.All(str, vol.Length(min=5, max=500)),
             vol.Optional("tone", default=existing.get("tone", DEFAULT_TONE)): vol.All(str, vol.Length(min=5, max=500)),
             vol.Optional("pronunciation", default=existing.get("pronunciation", DEFAULT_PRONUNCIATION)): vol.All(str, vol.Length(min=5, max=500)),

--- a/custom_components/openai_gpt4o_tts/const.py
+++ b/custom_components/openai_gpt4o_tts/const.py
@@ -8,10 +8,12 @@ CONF_API_KEY = "api_key"
 CONF_VOICE = "voice"
 CONF_INSTRUCTIONS = "instructions"
 CONF_LANGUAGE = "language"
+CONF_SPEED = "speed"
 
 # Default settings
 DEFAULT_VOICE = "sage"
 DEFAULT_LANGUAGE = "en"
+DEFAULT_SPEED = 1.0
 
 # Default multi-field instruction settings
 DEFAULT_AFFECT = (

--- a/custom_components/openai_gpt4o_tts/gpt4o.py
+++ b/custom_components/openai_gpt4o_tts/gpt4o.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 
-from .const import CONF_VOICE, CONF_INSTRUCTIONS
+from .const import CONF_VOICE, CONF_INSTRUCTIONS, CONF_SPEED, DEFAULT_SPEED
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,10 +16,11 @@ class GPT4oClient:
         # Always set your API key
         self._api_key = entry.data["api_key"]
 
-        # Pull default voice/instructions from options first, then legacy data
+        # Pull defaults from options first, then fallback to legacy data
         opts = getattr(entry, "options", {}) or {}
         self._voice = opts.get(CONF_VOICE, entry.data.get(CONF_VOICE))
         self._instructions = opts.get(CONF_INSTRUCTIONS, entry.data.get(CONF_INSTRUCTIONS))
+        self._speed = opts.get(CONF_SPEED, entry.data.get(CONF_SPEED, DEFAULT_SPEED))
 
         # Model name stays the same
         self._model = "gpt-4o-mini-tts"
@@ -32,6 +33,7 @@ class GPT4oClient:
         # Allow per‑call overrides, else use our stored defaults
         voice = options.get("voice", self._voice)
         instructions = options.get("instructions", self._instructions)
+        speed = float(options.get("speed", self._speed))
         audio_format = options.get("audio_output", "mp3")
 
         headers = {
@@ -44,6 +46,7 @@ class GPT4oClient:
             "input": text,
             "instructions": instructions,
             "response_format": audio_format,
+            "speed": speed,
         }
 
         def do_request():

--- a/custom_components/openai_gpt4o_tts/tts.py
+++ b/custom_components/openai_gpt4o_tts/tts.py
@@ -11,7 +11,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, OPENAI_TTS_VOICES, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE
+from .const import (
+    DOMAIN,
+    OPENAI_TTS_VOICES,
+    SUPPORTED_LANGUAGES,
+    DEFAULT_LANGUAGE,
+    CONF_SPEED,
+)
 from .gpt4o import GPT4oClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,13 +65,15 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
     @property
     def supported_options(self) -> list[str]:
         """Which TTS options can be overridden in the UI or service call."""
-        return [ATTR_VOICE, "instructions", ATTR_AUDIO_OUTPUT]
+        return [ATTR_VOICE, "instructions", ATTR_AUDIO_OUTPUT, CONF_SPEED]
 
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict | None = None
     ) -> TtsAudioType:
         """Called by Home Assistant to produce audio from text."""
-        audio_format, audio_data = await self._client.get_tts_audio(message, options)
+        audio_format, audio_data = await self._client.get_tts_audio(
+            message, options
+        )
         if not audio_data:
             return None, None
         return audio_format, audio_data


### PR DESCRIPTION
## Summary
- expose numeric `speed` setting in configuration with validation
- store speed as config option and pass it through to GPT4o API requests
- document the new option in the READMEs
- allow overriding `speed` from TTS service calls

## Testing
- `python -m py_compile custom_components/openai_gpt4o_tts/*.py`
- `flake8 custom_components/openai_gpt4o_tts/*.py` *(fails: E501 line too long in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_687de1fea88483318caa38c99558f112