### PR TITLE
Implement playback speed for GPT-4o Mini TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Since this is a **custom repository**, you must add it manually:
 - **Affect/Personality** (e.g., "A cheerful guide")  
 - **Tone** (e.g., "Friendly, clear, and reassuring")  
 - **Pronunciation** (e.g., "Clear, articulate, and steady")  
-- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")  
-- **Emotion** (e.g., "Warm and supportive")  
+- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")
+- **Emotion** (e.g., "Warm and supportive")
+- **Playback Speed** (e.g., `1.2` for 20% faster)
 6. Click **Submit**. 🎉 Done!  
 
 ![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)

--- a/custom_components/openai_gpt4o_tts/README.md
+++ b/custom_components/openai_gpt4o_tts/README.md
@@ -68,8 +68,9 @@ Since this is a **custom repository**, you must add it manually:
 - **Affect/Personality** (e.g., "A cheerful guide")  
 - **Tone** (e.g., "Friendly, clear, and reassuring")  
 - **Pronunciation** (e.g., "Clear, articulate, and steady")  
-- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")  
-- **Emotion** (e.g., "Warm and supportive")  
+- **Pauses** (e.g., "Brief, purposeful pauses after key instructions")
+- **Emotion** (e.g., "Warm and supportive")
+- **Playback Speed** (e.g., `1.2` for 20% faster)
 6. Click **Submit**. 🎉 Done!  
 
 ![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)

--- a/custom_components/openai_gpt4o_tts/__init__.py
+++ b/custom_components/openai_gpt4o_tts/__init__.py
@@ -7,6 +7,7 @@ from .gpt4o import GPT4oClient
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up GPT-4o TTS from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -21,6 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload GPT-4o TTS config entry."""

--- a/custom_components/openai_gpt4o_tts/config_flow.py
+++ b/custom_components/openai_gpt4o_tts/config_flow.py
@@ -19,6 +19,8 @@ from .const import (
     DEFAULT_EMOTION,
     OPENAI_TTS_VOICES,
     SUPPORTED_LANGUAGES,
+    CONF_PLAYBACK_SPEED,
+    DEFAULT_PLAYBACK_SPEED,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,6 +64,9 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_VOICE: user_input.get(CONF_VOICE, DEFAULT_VOICE),
                 CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
                 CONF_INSTRUCTIONS: user_input.get(CONF_INSTRUCTIONS, ""),
+                CONF_PLAYBACK_SPEED: float(
+                    user_input.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED)
+                ),
                 "affect_personality": affect,
                 "tone": tone,
                 "pronunciation": pron,
@@ -70,24 +75,43 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
 
             _LOGGER.debug("Creating entry with options: %s", options)
-            return self.async_create_entry(title="OpenAI GPT‑4o TTS", data=data, options=options)
+            return self.async_create_entry(
+                title="OpenAI GPT‑4o TTS", data=data, options=options
+            )
 
         # Show the setup form
-        data_schema = vol.Schema({
-            vol.Required(CONF_API_KEY): str,
-            vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(OPENAI_TTS_VOICES),
-            vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(SUPPORTED_LANGUAGES),
-            vol.Optional("affect_personality", default=DEFAULT_AFFECT): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("tone", default=DEFAULT_TONE): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("pronunciation", default=DEFAULT_PRONUNCIATION): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("pause", default=DEFAULT_PAUSE): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("emotion", default=DEFAULT_EMOTION): vol.All(str, vol.Length(min=5, max=500)),
-        })
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_API_KEY): str,
+                vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(
+                    OPENAI_TTS_VOICES
+                ),
+                vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
+                    SUPPORTED_LANGUAGES
+                ),
+                vol.Optional(
+                    CONF_PLAYBACK_SPEED, default=DEFAULT_PLAYBACK_SPEED
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.25, max=4.0)),
+                vol.Optional("affect_personality", default=DEFAULT_AFFECT): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("tone", default=DEFAULT_TONE): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("pronunciation", default=DEFAULT_PRONUNCIATION): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("pause", default=DEFAULT_PAUSE): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("emotion", default=DEFAULT_EMOTION): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+            }
+        )
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=data_schema,
-            errors=errors
+            step_id="user", data_schema=data_schema, errors=errors
         )
 
     @staticmethod
@@ -110,17 +134,36 @@ class OpenAIGPT4oOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         existing = self._entry.options or self._entry.data
-        data_schema = vol.Schema({
-            vol.Optional(CONF_VOICE, default=existing.get(CONF_VOICE, DEFAULT_VOICE)): vol.In(OPENAI_TTS_VOICES),
-            vol.Optional(CONF_LANGUAGE, default=existing.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)): vol.In(SUPPORTED_LANGUAGES),
-            vol.Optional("affect_personality", default=existing.get("affect_personality", DEFAULT_AFFECT)): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("tone", default=existing.get("tone", DEFAULT_TONE)): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("pronunciation", default=existing.get("pronunciation", DEFAULT_PRONUNCIATION)): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("pause", default=existing.get("pause", DEFAULT_PAUSE)): vol.All(str, vol.Length(min=5, max=500)),
-            vol.Optional("emotion", default=existing.get("emotion", DEFAULT_EMOTION)): vol.All(str, vol.Length(min=5, max=500)),
-        })
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=data_schema
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_VOICE, default=existing.get(CONF_VOICE, DEFAULT_VOICE)
+                ): vol.In(OPENAI_TTS_VOICES),
+                vol.Optional(
+                    CONF_LANGUAGE, default=existing.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)
+                ): vol.In(SUPPORTED_LANGUAGES),
+                vol.Optional(
+                    CONF_PLAYBACK_SPEED,
+                    default=existing.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED),
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.25, max=4.0)),
+                vol.Optional(
+                    "affect_personality",
+                    default=existing.get("affect_personality", DEFAULT_AFFECT),
+                ): vol.All(str, vol.Length(min=5, max=500)),
+                vol.Optional(
+                    "tone", default=existing.get("tone", DEFAULT_TONE)
+                ): vol.All(str, vol.Length(min=5, max=500)),
+                vol.Optional(
+                    "pronunciation",
+                    default=existing.get("pronunciation", DEFAULT_PRONUNCIATION),
+                ): vol.All(str, vol.Length(min=5, max=500)),
+                vol.Optional(
+                    "pause", default=existing.get("pause", DEFAULT_PAUSE)
+                ): vol.All(str, vol.Length(min=5, max=500)),
+                vol.Optional(
+                    "emotion", default=existing.get("emotion", DEFAULT_EMOTION)
+                ): vol.All(str, vol.Length(min=5, max=500)),
+            }
         )
+
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/openai_gpt4o_tts/const.py
+++ b/custom_components/openai_gpt4o_tts/const.py
@@ -8,25 +8,21 @@ CONF_API_KEY = "api_key"
 CONF_VOICE = "voice"
 CONF_INSTRUCTIONS = "instructions"
 CONF_LANGUAGE = "language"
+CONF_PLAYBACK_SPEED = "playback_speed"
 
 # Default settings
 DEFAULT_VOICE = "sage"
 DEFAULT_LANGUAGE = "en"
+DEFAULT_PLAYBACK_SPEED = 1.0
 
 # Default multi-field instruction settings
 DEFAULT_AFFECT = (
     "A cheerful guide who delivers speech in a lively and engaging manner, "
     "tailoring pronunciation clearly for the listener."
 )
-DEFAULT_TONE = (
-    "A conversational, friendly tone suitable for general-purpose speech."
-)
-DEFAULT_PRONUNCIATION = (
-    "Use standard pronunciation for the language of the message."
-)
-DEFAULT_PAUSE = (
-    "Insert brief, natural pauses between sentences."
-)
+DEFAULT_TONE = "A conversational, friendly tone suitable for general-purpose speech."
+DEFAULT_PRONUNCIATION = "Use standard pronunciation for the language of the message."
+DEFAULT_PAUSE = "Insert brief, natural pauses between sentences."
 DEFAULT_EMOTION = (
     "Subtly expressive; match the content’s sentiment without over‑acting."
 )
@@ -47,9 +43,61 @@ OPENAI_TTS_VOICES = [
 
 # Full Whisper‑level language support (ISO‑639‑1 codes)
 SUPPORTED_LANGUAGES = [
-    "af","ar","hy","az","be","bs","bg","ca","zh","hr","cs","da","nl",
-    "en","et","fi","fr","gl","de","el","he","hi","hu","is","id","it",
-    "ja","kn","kk","ko","lv","lt","mk","ms","mr","mi","ne","no","fa",
-    "pl","pt","ro","ru","sr","sk","sl","es","sw","sv","tl","ta","th",
-    "tr","uk","ur","vi","cy"
+    "af",
+    "ar",
+    "hy",
+    "az",
+    "be",
+    "bs",
+    "bg",
+    "ca",
+    "zh",
+    "hr",
+    "cs",
+    "da",
+    "nl",
+    "en",
+    "et",
+    "fi",
+    "fr",
+    "gl",
+    "de",
+    "el",
+    "he",
+    "hi",
+    "hu",
+    "is",
+    "id",
+    "it",
+    "ja",
+    "kn",
+    "kk",
+    "ko",
+    "lv",
+    "lt",
+    "mk",
+    "ms",
+    "mr",
+    "mi",
+    "ne",
+    "no",
+    "fa",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sr",
+    "sk",
+    "sl",
+    "es",
+    "sw",
+    "sv",
+    "tl",
+    "ta",
+    "th",
+    "tr",
+    "uk",
+    "ur",
+    "vi",
+    "cy",
 ]

--- a/custom_components/openai_gpt4o_tts/manifest.json
+++ b/custom_components/openai_gpt4o_tts/manifest.json
@@ -5,7 +5,8 @@
     "author": "wifiuk",
     "documentation": "https://github.com/wifiuk/OpenAI-GPT-4o-Mini-TTS-Home-Assistant-Integration",
     "requirements": [
-      "requests>=2.31.0"
+      "requests>=2.31.0",
+      "aiohttp>=3.9.3"
     ],
     "codeowners": [
       "@wifiuk"

--- a/custom_components/openai_gpt4o_tts/tts.py
+++ b/custom_components/openai_gpt4o_tts/tts.py
@@ -11,7 +11,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, OPENAI_TTS_VOICES, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE
+from .const import (
+    DOMAIN,
+    OPENAI_TTS_VOICES,
+    SUPPORTED_LANGUAGES,
+    DEFAULT_LANGUAGE,
+    CONF_PLAYBACK_SPEED,
+)
 from .gpt4o import GPT4oClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up GPT‑4o TTS from a config entry."""
     client = hass.data[DOMAIN][config_entry.entry_id]
@@ -59,7 +65,7 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
     @property
     def supported_options(self) -> list[str]:
         """Which TTS options can be overridden in the UI or service call."""
-        return [ATTR_VOICE, "instructions", ATTR_AUDIO_OUTPUT]
+        return [ATTR_VOICE, "instructions", ATTR_AUDIO_OUTPUT, CONF_PLAYBACK_SPEED]
 
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict | None = None


### PR DESCRIPTION
## Summary
- expose playback speed config option
- support playback speed in OpenAI client
- allow editing playback speed in options flow
- document playback speed setting
- use aiohttp for async streaming of TTS data
- fix Windows line endings

## Testing
- `python -m py_compile custom_components/openai_gpt4o_tts/*.py`
- `python -m black custom_components/openai_gpt4o_tts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687e83c992d48331beae8ba6f5d85cca