### PR TITLE
Fix instructions handling

### DIFF
--- a/custom_components/openai_gpt4o_tts/gpt4o.py
+++ b/custom_components/openai_gpt4o_tts/gpt4o.py
@@ -9,6 +9,7 @@ from .const import (
     CONF_PLAYBACK_SPEED,
     CONF_VOICE,
     DEFAULT_PLAYBACK_SPEED,
+    DEFAULT_VOICE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +64,11 @@ class GPT4oClient:
 
         # Allow per‑call overrides, else use our stored defaults
         voice = options.get("voice", self._voice)
+        if not voice:
+            voice = DEFAULT_VOICE
         instructions = options.get("instructions", self._instructions)
+        if instructions is None:
+            instructions = ""
         audio_format = options.get("audio_output", "mp3")
 
         headers = {

--- a/tests/test_gpt4o_client.py
+++ b/tests/test_gpt4o_client.py
@@ -1,0 +1,86 @@
+import asyncio
+import os
+import sys
+import importlib.util
+import types
+from types import SimpleNamespace
+
+import pytest
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# Stub minimal Home Assistant modules required for import
+ha = types.ModuleType("homeassistant")
+ha.config_entries = types.ModuleType("config_entries")
+ha.core = types.ModuleType("core")
+ha.helpers = types.ModuleType("helpers")
+ha.helpers.entity_platform = types.ModuleType("entity_platform")
+ha.components = types.ModuleType("components")
+ha.components.tts = types.ModuleType("tts")
+ha.config_entries.ConfigEntry = object
+ha.core.HomeAssistant = object
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
+sys.modules.setdefault("homeassistant.core", ha.core)
+sys.modules.setdefault("homeassistant.helpers", ha.helpers)
+sys.modules.setdefault("homeassistant.helpers.entity_platform", ha.helpers.entity_platform)
+sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.tts", ha.components.tts)
+
+sys.path.insert(0, BASE_DIR)
+gpt4o = importlib.import_module("custom_components.openai_gpt4o_tts.gpt4o")
+GPT4oClient = gpt4o.GPT4oClient
+DEFAULT_VOICE = gpt4o.DEFAULT_VOICE
+
+class DummyEntry:
+    def __init__(self, data=None, options=None):
+        self.data = data or {}
+        self.options = options or {}
+
+class DummyContent:
+    async def iter_chunked(self, size):
+        yield b"audio"
+
+class DummyResponse:
+    def __init__(self):
+        self.status = 200
+        self.content = DummyContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        return {}
+
+    async def text(self):
+        return ""
+
+class DummySession:
+    def __init__(self, *args, **kwargs):
+        self.payload = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, headers=None, json=None):
+        self.payload = json
+        return DummyResponse()
+
+@pytest.mark.asyncio
+async def test_instructions_default(monkeypatch):
+    entry = DummyEntry(data={"api_key": "k"})
+    client = GPT4oClient(None, entry)
+
+    dummy = DummySession()
+    monkeypatch.setattr("custom_components.openai_gpt4o_tts.gpt4o.ClientSession", lambda timeout=None: dummy)
+
+    fmt, data = await client.get_tts_audio("hello")
+    assert fmt == "mp3"
+    assert dummy.payload["instructions"] == ""
+    assert dummy.payload["voice"] == DEFAULT_VOICE


### PR DESCRIPTION
## Summary
- avoid `None` when `instructions` isn't set
- fall back to default voice when no voice provided
- add unit test for payload defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8f9b8ea88331aa48d99a7ba75d0f