### PR TITLE
Add reload listener for options updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ With **11 built-in voices**, you can customise **how speech is rendered** to mat
 ✅ **Fully UI-based setup**—no YAML required  
 ✅ **11 voices** (`alloy`, `ash`, `ballad`, `coral`, `echo`, etc.)  
 ✅ **Customisable speech**—affect, tone, pronunciation, pauses, emotion  
-✅ **Works with Home Assistant’s Assist**  
-✅ **Easily installable via HACS**  
+✅ **Works with Home Assistant’s Assist**
+✅ **Easily installable via HACS**
+✅ **Playback speed control for faster or slower speech**
+✅ **Streaming audio for quicker responses**
+✅ **Changes take effect immediately – no restart required**
+✅ **Improved error handling and logging**
 
 ---
 

--- a/custom_components/openai_gpt4o_tts/README.md
+++ b/custom_components/openai_gpt4o_tts/README.md
@@ -26,8 +26,12 @@ With **11 built-in voices**, you can customise **how speech is rendered** to mat
 ✅ **Fully UI-based setup**—no YAML required  
 ✅ **11 voices** (`alloy`, `ash`, `ballad`, `coral`, `echo`, etc.)  
 ✅ **Customisable speech**—affect, tone, pronunciation, pauses, emotion  
-✅ **Works with Home Assistant’s Assist**  
-✅ **Easily installable via HACS**  
+✅ **Works with Home Assistant’s Assist**
+✅ **Easily installable via HACS**
+✅ **Playback speed control for faster or slower speech**
+✅ **Streaming audio for quicker responses**
+✅ **Changes take effect immediately – no restart required**
+✅ **Improved error handling and logging**
 
 ---
 

--- a/custom_components/openai_gpt4o_tts/__init__.py
+++ b/custom_components/openai_gpt4o_tts/__init__.py
@@ -5,6 +5,11 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN, PLATFORMS
 from .gpt4o import GPT4oClient
 
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload when options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -12,11 +17,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up GPT-4o TTS from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    # Store the config entry so it persists
-    hass.data[DOMAIN][entry.entry_id] = entry
-
     # Initialize the GPT-4o TTS client
     hass.data[DOMAIN][entry.entry_id] = GPT4oClient(hass, entry)
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     # Forward to TTS platform so HA creates 'tts.openai_gpt4o_tts_say'
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/tests/test_update_listener.py
+++ b/tests/test_update_listener.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import importlib
+import types
+from types import SimpleNamespace
+
+import pytest
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# Stub minimal Home Assistant modules
+ha = types.ModuleType("homeassistant")
+ha.config_entries = types.ModuleType("config_entries")
+ha.core = types.ModuleType("core")
+ha.config_entries.ConfigEntry = object
+ha.core.HomeAssistant = object
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
+sys.modules.setdefault("homeassistant.core", ha.core)
+
+sys.path.insert(0, BASE_DIR)
+init = importlib.import_module("custom_components.openai_gpt4o_tts.__init__")
+
+
+class DummyConfigEntries:
+    def __init__(self):
+        self.reloaded = None
+
+    async def async_reload(self, entry_id):
+        self.reloaded = entry_id
+
+
+@pytest.mark.asyncio
+async def test_update_listener_triggers_reload():
+    hass = SimpleNamespace(config_entries=DummyConfigEntries())
+    entry = SimpleNamespace(entry_id="abc")
+    await init._async_update_listener(hass, entry)
+    assert hass.config_entries.reloaded == "abc"


### PR DESCRIPTION
## Summary
- reload config entry when options are updated
- add regression test for the update listener
- document playback speed and new update behavior in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e984bb59883318c7dbfc3c418aec5