### PR TITLE
Allow configuring OpenAI TTS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ Since this is a **custom repository**, you must add it manually:
 - **Pauses** (e.g., "Brief, purposeful pauses after key instructions")
 - **Emotion** (e.g., "Warm and supportive")
 - **Playback Speed** (e.g., `1.2` for 20% faster)
-6. Click **Submit**. 🎉 Done!  
+- **Model** (e.g., `gpt-4o-mini-tts`)
+- **Audio Format** (e.g., `mp3`, `wav`)
+- **Stream Format** (e.g., `audio` or `sse`)
+6. Click **Submit**. 🎉 Done!
 
 ![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)
 

--- a/custom_components/openai_gpt4o_tts/README.md
+++ b/custom_components/openai_gpt4o_tts/README.md
@@ -75,7 +75,10 @@ Since this is a **custom repository**, you must add it manually:
 - **Pauses** (e.g., "Brief, purposeful pauses after key instructions")
 - **Emotion** (e.g., "Warm and supportive")
 - **Playback Speed** (e.g., `1.2` for 20% faster)
-6. Click **Submit**. 🎉 Done!  
+- **Model** (e.g., `gpt-4o-mini-tts`)
+- **Audio Format** (e.g., `mp3`, `wav`)
+- **Stream Format** (e.g., `audio` or `sse`)
+6. Click **Submit**. 🎉 Done!
 
 ![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)
 

--- a/custom_components/openai_gpt4o_tts/config_flow.py
+++ b/custom_components/openai_gpt4o_tts/config_flow.py
@@ -19,8 +19,17 @@ from .const import (
     DEFAULT_EMOTION,
     OPENAI_TTS_VOICES,
     SUPPORTED_LANGUAGES,
+    OPENAI_TTS_MODELS,
+    OPENAI_AUDIO_FORMATS,
+    OPENAI_STREAM_FORMATS,
     CONF_PLAYBACK_SPEED,
     DEFAULT_PLAYBACK_SPEED,
+    CONF_MODEL,
+    CONF_AUDIO_OUTPUT,
+    CONF_STREAM_FORMAT,
+    DEFAULT_MODEL,
+    DEFAULT_AUDIO_OUTPUT,
+    DEFAULT_STREAM_FORMAT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +74,9 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_VOICE: user_input.get(CONF_VOICE, DEFAULT_VOICE),
                 CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
                 CONF_INSTRUCTIONS: user_input.get(CONF_INSTRUCTIONS, ""),
+                CONF_MODEL: user_input.get(CONF_MODEL, DEFAULT_MODEL),
+                CONF_AUDIO_OUTPUT: user_input.get(CONF_AUDIO_OUTPUT, DEFAULT_AUDIO_OUTPUT),
+                CONF_STREAM_FORMAT: user_input.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT),
                 CONF_PLAYBACK_SPEED: float(
                     user_input.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED)
                 ),
@@ -89,6 +101,15 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
                     SUPPORTED_LANGUAGES
+                ),
+                vol.Optional(CONF_MODEL, default=DEFAULT_MODEL): vol.In(
+                    OPENAI_TTS_MODELS
+                ),
+                vol.Optional(CONF_AUDIO_OUTPUT, default=DEFAULT_AUDIO_OUTPUT): vol.In(
+                    OPENAI_AUDIO_FORMATS
+                ),
+                vol.Optional(CONF_STREAM_FORMAT, default=DEFAULT_STREAM_FORMAT): vol.In(
+                    OPENAI_STREAM_FORMATS
                 ),
                 vol.Optional(
                     CONF_PLAYBACK_SPEED, default=DEFAULT_PLAYBACK_SPEED
@@ -143,6 +164,17 @@ class OpenAIGPT4oOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_LANGUAGE, default=existing.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)
                 ): vol.In(SUPPORTED_LANGUAGES),
+                vol.Optional(
+                    CONF_MODEL, default=existing.get(CONF_MODEL, DEFAULT_MODEL)
+                ): vol.In(OPENAI_TTS_MODELS),
+                vol.Optional(
+                    CONF_AUDIO_OUTPUT,
+                    default=existing.get(CONF_AUDIO_OUTPUT, DEFAULT_AUDIO_OUTPUT),
+                ): vol.In(OPENAI_AUDIO_FORMATS),
+                vol.Optional(
+                    CONF_STREAM_FORMAT,
+                    default=existing.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT),
+                ): vol.In(OPENAI_STREAM_FORMATS),
                 vol.Optional(
                     CONF_PLAYBACK_SPEED,
                     default=existing.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED),

--- a/custom_components/openai_gpt4o_tts/const.py
+++ b/custom_components/openai_gpt4o_tts/const.py
@@ -9,11 +9,17 @@ CONF_VOICE = "voice"
 CONF_INSTRUCTIONS = "instructions"
 CONF_LANGUAGE = "language"
 CONF_PLAYBACK_SPEED = "playback_speed"
+CONF_MODEL = "model"
+CONF_AUDIO_OUTPUT = "audio_output"
+CONF_STREAM_FORMAT = "stream_format"
 
 # Default settings
 DEFAULT_VOICE = "sage"
 DEFAULT_LANGUAGE = "en"
 DEFAULT_PLAYBACK_SPEED = 1.0
+DEFAULT_MODEL = "gpt-4o-mini-tts"
+DEFAULT_AUDIO_OUTPUT = "mp3"
+DEFAULT_STREAM_FORMAT = "audio"
 
 # Default multi-field instruction settings
 DEFAULT_AFFECT = (
@@ -40,6 +46,11 @@ OPENAI_TTS_VOICES = [
     "sage",
     "shimmer",
 ]
+
+# Supported models and formats
+OPENAI_TTS_MODELS = ["tts-1", "tts-1-hd", "gpt-4o-mini-tts"]
+OPENAI_AUDIO_FORMATS = ["mp3", "opus", "aac", "flac", "wav", "pcm"]
+OPENAI_STREAM_FORMATS = ["audio", "sse"]
 
 # Full Whisper‑level language support (ISO‑639‑1 codes)
 SUPPORTED_LANGUAGES = [

--- a/custom_components/openai_gpt4o_tts/tts.py
+++ b/custom_components/openai_gpt4o_tts/tts.py
@@ -17,6 +17,8 @@ from .const import (
     SUPPORTED_LANGUAGES,
     DEFAULT_LANGUAGE,
     CONF_PLAYBACK_SPEED,
+    CONF_MODEL,
+    CONF_STREAM_FORMAT,
 )
 from .gpt4o import GPT4oClient
 
@@ -60,12 +62,19 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
     @property
     def default_options(self) -> dict:
         """Default TTS options, e.g. mp3."""
-        return {ATTR_AUDIO_OUTPUT: "mp3"}
+        return {ATTR_AUDIO_OUTPUT: self._client.audio_output}
 
     @property
     def supported_options(self) -> list[str]:
         """Which TTS options can be overridden in the UI or service call."""
-        return [ATTR_VOICE, "instructions", ATTR_AUDIO_OUTPUT, CONF_PLAYBACK_SPEED]
+        return [
+            ATTR_VOICE,
+            "instructions",
+            ATTR_AUDIO_OUTPUT,
+            CONF_PLAYBACK_SPEED,
+            CONF_MODEL,
+            CONF_STREAM_FORMAT,
+        ]
 
     async def async_get_tts_audio(
         self, message: str, language: str, options: dict | None = None

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -107,3 +107,6 @@ async def test_api_key_whitespace(monkeypatch):
     fmt, data = await client.get_tts_audio("hi")
     assert fmt == "mp3"
     assert dummy.headers["Authorization"] == "Bearer k"
+    assert dummy.payload["model"] == gpt4o.DEFAULT_MODEL
+    assert dummy.payload["response_format"] == gpt4o.DEFAULT_AUDIO_OUTPUT
+    assert dummy.payload["stream_format"] == gpt4o.DEFAULT_STREAM_FORMAT

--- a/tests/test_gpt4o_client.py
+++ b/tests/test_gpt4o_client.py
@@ -84,6 +84,9 @@ async def test_instructions_default(monkeypatch):
     assert fmt == "mp3"
     assert dummy.payload["instructions"] == ""
     assert dummy.payload["voice"] == DEFAULT_VOICE
+    assert dummy.payload["model"] == gpt4o.DEFAULT_MODEL
+    assert dummy.payload["response_format"] == gpt4o.DEFAULT_AUDIO_OUTPUT
+    assert dummy.payload["stream_format"] == gpt4o.DEFAULT_STREAM_FORMAT
 
 
 class ErrorResponse:


### PR DESCRIPTION
## Summary
- expose additional API settings like model and audio format
- support new configuration options in the UI flow
- pass selected options to the OpenAI API
- document new settings in the README
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687faf0867c88331864c288f92ca2598