### PR TITLE
Refactor HA stubs into shared fixture

### DIFF
--- a/tests/hass_stubs.py
+++ b/tests/hass_stubs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from collections.abc import AsyncGenerator
+
+
+def install_homeassistant_stubs() -> None:
+    """Install minimal Home Assistant module stubs for unit tests."""
+    if "homeassistant" in sys.modules:
+        return
+
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []
+
+    ha.components = types.ModuleType("components")
+    ha.components.__path__ = []
+    tts = types.ModuleType("tts")
+    tts.__package__ = "homeassistant.components"
+    tts.__path__ = []
+    tts.TextToSpeechEntity = object
+    tts.ATTR_AUDIO_OUTPUT = "audio_output"
+    tts.ATTR_VOICE = "voice"
+    tts.Voice = object
+    tts.TtsAudioType = tuple[str | None, bytes | None]
+
+    @dataclass
+    class TTSAudioRequest:
+        language: str
+        options: dict
+        message_gen: AsyncGenerator[str, None]
+
+    @dataclass
+    class TTSAudioResponse:
+        extension: str
+        data_gen: AsyncGenerator[bytes, None]
+
+    tts.TTSAudioRequest = TTSAudioRequest
+    tts.TTSAudioResponse = TTSAudioResponse
+
+    ha.components.tts = tts
+
+    ha.config_entries = types.ModuleType("config_entries")
+    ha.config_entries.CONN_CLASS_CLOUD_POLL = "cloud_poll"
+
+    class _BaseConfigFlow:
+        def __init_subclass__(cls, *args, domain=None, **kwargs):
+            super().__init_subclass__(*args, **kwargs)
+            cls.domain = domain
+
+        def async_show_form(self, **kwargs):
+            return kwargs
+
+        def async_create_entry(self, **kwargs):
+            self.created_entry = kwargs
+            return kwargs
+
+    ha.config_entries.ConfigFlow = _BaseConfigFlow
+    ha.config_entries.OptionsFlow = object
+    ha.config_entries.ConfigEntry = object
+
+    ha.core = types.ModuleType("core")
+    ha.core.HomeAssistant = object
+    ha.core.callback = lambda func: func
+
+    ha.helpers = types.ModuleType("helpers")
+    ha.helpers.entity_platform = types.ModuleType("entity_platform")
+    ha.helpers.entity_platform.AddEntitiesCallback = object
+
+    ha.exceptions = types.ModuleType("exceptions")
+
+    class HomeAssistantError(Exception):
+        """Basic Home Assistant error for tests."""
+
+    ha.exceptions.HomeAssistantError = HomeAssistantError
+
+    ha.const = types.ModuleType("const")
+    ha.const.CONF_API_KEY = "api_key"
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.components"] = ha.components
+    sys.modules["homeassistant.components.tts"] = tts
+    sys.modules["homeassistant.config_entries"] = ha.config_entries
+    sys.modules["homeassistant.core"] = ha.core
+    sys.modules["homeassistant.helpers"] = ha.helpers
+    sys.modules["homeassistant.helpers.entity_platform"] = ha.helpers.entity_platform
+    sys.modules["homeassistant.exceptions"] = ha.exceptions
+    sys.modules["homeassistant.const"] = ha.const

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,46 +1,15 @@
 import os
 import sys
 import importlib
-import types
 
 import pytest
 
+sys.path.insert(0, os.path.dirname(__file__))
+from hass_stubs import install_homeassistant_stubs
+
+install_homeassistant_stubs()
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
-# Stub minimal Home Assistant modules required for import
-ha = types.ModuleType("homeassistant")
-ha.config_entries = types.ModuleType("config_entries")
-ha.core = types.ModuleType("core")
-ha.const = types.ModuleType("const")
-
-ha.config_entries.CONN_CLASS_CLOUD_POLL = "cloud_poll"
-ha.const.CONF_API_KEY = "api_key"
-
-
-class _BaseConfigFlow:
-    def __init_subclass__(cls, *args, domain=None, **kwargs):
-        super().__init_subclass__(*args, **kwargs)
-        cls.domain = domain
-
-    def async_show_form(self, **kwargs):
-        return kwargs
-
-    def async_create_entry(self, **kwargs):
-        self.created_entry = kwargs
-        return kwargs
-
-
-ha.config_entries.ConfigFlow = _BaseConfigFlow
-ha.config_entries.OptionsFlow = object
-ha.config_entries.ConfigEntry = object
-ha.core.HomeAssistant = object
-ha.core.callback = lambda func: func
-
-sys.modules.setdefault("homeassistant", ha)
-sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
-sys.modules.setdefault("homeassistant.core", ha.core)
-sys.modules.setdefault("homeassistant.const", ha.const)
-
 sys.path.insert(0, BASE_DIR)
 
 cfg_flow = importlib.import_module("custom_components.openai_gpt4o_tts.config_flow")

--- a/tests/test_gpt4o_client.py
+++ b/tests/test_gpt4o_client.py
@@ -1,35 +1,19 @@
 import asyncio
 import os
 import sys
-import importlib.util
-import types
+import importlib
 from types import SimpleNamespace
 
 import pytest
 
+sys.path.insert(0, os.path.dirname(__file__))
+from hass_stubs import install_homeassistant_stubs
+
+install_homeassistant_stubs()
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
-# Stub minimal Home Assistant modules required for import
-ha = types.ModuleType("homeassistant")
-ha.config_entries = types.ModuleType("config_entries")
-ha.core = types.ModuleType("core")
-ha.helpers = types.ModuleType("helpers")
-ha.helpers.entity_platform = types.ModuleType("entity_platform")
-ha.components = types.ModuleType("components")
-ha.components.tts = types.ModuleType("tts")
-ha.config_entries.ConfigEntry = object
-ha.core.HomeAssistant = object
-sys.modules.setdefault("homeassistant", ha)
-sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
-sys.modules.setdefault("homeassistant.core", ha.core)
-sys.modules.setdefault("homeassistant.helpers", ha.helpers)
-sys.modules.setdefault(
-    "homeassistant.helpers.entity_platform", ha.helpers.entity_platform
-)
-sys.modules.setdefault("homeassistant.components", ha.components)
-sys.modules.setdefault("homeassistant.components.tts", ha.components.tts)
-
 sys.path.insert(0, BASE_DIR)
+
 gpt4o = importlib.import_module("custom_components.openai_gpt4o_tts.gpt4o")
 GPT4oClient = gpt4o.GPT4oClient
 DEFAULT_VOICE = gpt4o.DEFAULT_VOICE

--- a/tests/test_tts_provider.py
+++ b/tests/test_tts_provider.py
@@ -1,66 +1,18 @@
 import os
 import sys
-import types
 import importlib
-from dataclasses import dataclass
 from collections.abc import AsyncGenerator
+
 import pytest
 
+sys.path.insert(0, os.path.dirname(__file__))
+from hass_stubs import install_homeassistant_stubs
+
+install_homeassistant_stubs()
+
+from homeassistant.components.tts import TTSAudioRequest, TTSAudioResponse
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
-# Stub minimal Home Assistant modules required for import
-ha = types.ModuleType("homeassistant")
-ha.__path__ = []
-ha.components = types.ModuleType("components")
-ha.components.__path__ = []
-ha.components.tts = types.ModuleType("tts")
-ha.components.tts.__package__ = "homeassistant.components"
-ha.components.tts.__path__ = []
-ha.components.tts.TextToSpeechEntity = object
-ha.components.tts.ATTR_AUDIO_OUTPUT = "audio_output"
-ha.components.tts.ATTR_VOICE = "voice"
-ha.components.tts.Voice = object
-ha.components.tts.TtsAudioType = tuple[str | None, bytes | None]
-
-ha.config_entries = types.ModuleType("config_entries")
-ha.core = types.ModuleType("core")
-ha.helpers = types.ModuleType("helpers")
-ha.helpers.entity_platform = types.ModuleType("entity_platform")
-ha.exceptions = types.ModuleType("exceptions")
-
-# Basic attributes used in tts provider
-@dataclass
-class TTSAudioRequest:
-    language: str
-    options: dict
-    message_gen: AsyncGenerator[str]
-
-@dataclass
-class TTSAudioResponse:
-    extension: str
-    data_gen: AsyncGenerator[bytes]
-
-ha.components.tts.TTSAudioRequest = TTSAudioRequest
-ha.components.tts.TTSAudioResponse = TTSAudioResponse
-ha.components.tts.TextToSpeechEntity = object
-
-class HomeAssistantError(Exception):
-    pass
-ha.exceptions.HomeAssistantError = HomeAssistantError
-
-ha.config_entries.ConfigEntry = object
-ha.core.HomeAssistant = object
-ha.helpers.entity_platform.AddEntitiesCallback = object
-
-sys.modules["homeassistant"] = ha
-sys.modules["homeassistant.components"] = ha.components
-sys.modules["homeassistant.components.tts"] = ha.components.tts
-sys.modules["homeassistant.config_entries"] = ha.config_entries
-sys.modules["homeassistant.core"] = ha.core
-sys.modules["homeassistant.helpers"] = ha.helpers
-sys.modules["homeassistant.helpers.entity_platform"] = ha.helpers.entity_platform
-sys.modules["homeassistant.exceptions"] = ha.exceptions
-
 sys.path.insert(0, BASE_DIR)
 
 # Import after stubs are in place

--- a/tests/test_update_listener.py
+++ b/tests/test_update_listener.py
@@ -1,23 +1,16 @@
 import os
 import sys
 import importlib
-import types
 from types import SimpleNamespace
 
 import pytest
 
+sys.path.insert(0, os.path.dirname(__file__))
+from hass_stubs import install_homeassistant_stubs
+
+install_homeassistant_stubs()
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
-# Stub minimal Home Assistant modules
-ha = types.ModuleType("homeassistant")
-ha.config_entries = types.ModuleType("config_entries")
-ha.core = types.ModuleType("core")
-ha.config_entries.ConfigEntry = object
-ha.core.HomeAssistant = object
-sys.modules.setdefault("homeassistant", ha)
-sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
-sys.modules.setdefault("homeassistant.core", ha.core)
-
 sys.path.insert(0, BASE_DIR)
 init = importlib.import_module("custom_components.openai_gpt4o_tts.__init__")
 


### PR DESCRIPTION
## Summary
- create `hass_stubs` module under `tests` with minimal HA mocks
- use shared stubs in all tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688082922ac48331a2fb1d813ef1ecc9