### PR TITLE
Fix SSE streaming parser and bump version to 1.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pytest
 - API keys are stored by Home Assistant and masked in logs.
 - All outbound calls enforce HTTPS endpoints, 30s client timeout, and no shell commands are executed.
 - PCM responses are decoded from base64 before streaming to avoid feeding invalid data into ffmpeg pipelines.
+- Streaming responses validate UTF-8 SSE chunks and bound buffering to 1 MB to avoid connection resets and resource exhaustion.
 
 ## Limitations
 - Network access to OpenAI/Azure is required; the integration does not cache audio.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 - **Transport**: Only HTTPS endpoints are accepted. Client requests enforce a 30s timeout and never shell out, reducing injection and SSRF risk (OWASP A5:2021 Security Misconfiguration, A10:2021 Server-Side Request Forgery).
 - **Input validation**: Configuration schemas restrict provider, voice, model, audio format, playback speed, and volume gain. Gain is clamped to `0.1–3.0` at runtime to avoid clipping or harmful playback (OWASP A4:2021 Insecure Design).
 - **Output handling**: Audio returned from providers is normalised to binary and sanitized before being passed to ffmpeg, preventing malformed base64 payloads from propagating downstream (OWASP A1:2021 Broken Access Control via injection vectors).
+- **Streaming safety**: Server-Sent Events are decoded with strict UTF-8 handling and a 1 MB rolling buffer cap, dropping malformed chunks to mitigate connection resets or memory exhaustion (OWASP A6:2021 Vulnerable and Outdated Components / A8:2021 Software and Data Integrity Failures).
 - **Dependencies**: Optional FFmpeg/pydub components must be maintained by the operator to avoid vulnerable codecs (OWASP A6:2021 Vulnerable and Outdated Components).
 
 ## Assumptions & Risks

--- a/custom_components/openai_gpt4o_tts/manifest.json
+++ b/custom_components/openai_gpt4o_tts/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "openai_gpt4o_tts",
     "name": "OpenAI GPT-4o Mini TTS",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "author": "wifiuk",
     "documentation": "https://github.com/wifiuk/OpenAI-GPT-4o-Mini-TTS-Home-Assistant-Integration",
     "requirements": ["aiohttp>=3.9.3"],


### PR DESCRIPTION
## Summary
- harden the SSE streaming parser to handle chunked payloads, UTF-8 validation, and buffer limits to prevent connection drops
- expand unit coverage for SSE edge cases and update documentation with new streaming safeguards
- bump the integration version to 1.0.12

## Testing
- pytest *(fails: missing aiohttp / voluptuous test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cef85e3c8331aa0e18443ad2fb4f