### PR TITLE
Restore integration files from v1.0.9 release

### DIFF
--- a/custom_components/openai_gpt4o_tts/README.md
+++ b/custom_components/openai_gpt4o_tts/README.md
@@ -77,10 +77,9 @@ Since this is a **custom repository**, you must add it manually:
 - **Model** (e.g., `gpt-4o-mini-tts`)
 - **Audio Format** (e.g., `mp3`, `wav`)
 - **Stream Format** – choose `sse` to stream audio while it is generated or `audio` to wait for the full file
-6. Click **Submit**. 🎉 Done!  
+6. Click **Submit**. 🎉 Done!
 
-
-<img width="334" height="1045" alt="image" src="https://github.com/user-attachments/assets/fb6f147e-b016-4766-bcb9-f1ddeec87ffa" />
+![image](https://github.com/user-attachments/assets/a533cb82-8b6e-4689-8d0f-c6df0b83dc3c)
 
 
 Now, Home Assistant's voice assistant will use GPT-4o Mini TTS as its **speech provider**.

--- a/custom_components/openai_gpt4o_tts/config_flow.py
+++ b/custom_components/openai_gpt4o_tts/config_flow.py
@@ -7,14 +7,9 @@ from homeassistant.core import callback
 
 from .const import (
     DOMAIN,
-    CONF_PROVIDER,
-    CONF_AZURE_ENDPOINT,
     CONF_VOICE,
     CONF_INSTRUCTIONS,
     CONF_LANGUAGE,
-    PROVIDER_OPENAI,
-    PROVIDER_AZURE,
-    DEFAULT_PROVIDER,
     DEFAULT_VOICE,
     DEFAULT_LANGUAGE,
     DEFAULT_AFFECT,
@@ -35,13 +30,10 @@ from .const import (
     DEFAULT_MODEL,
     DEFAULT_AUDIO_OUTPUT,
     DEFAULT_STREAM_FORMAT,
-    CONF_VOLUME_GAIN,
-    DEFAULT_VOLUME_GAIN,
-    VOLUME_GAIN_MIN,
-    VOLUME_GAIN_MAX,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle OpenAI GPT‑4o Mini TTS setup flow."""
@@ -49,23 +41,93 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    def __init__(self):
-        """Initialize the config flow."""
-        self._provider = None
-
-    async def async_step_user(self, user_input=None):
-        """Handle provider selection step."""
-        errors = {}
+    async def async_step_user(self, user_input=None, errors=None):
+        """Initial configuration step."""
+        errors = errors or {}
 
         if user_input is not None:
-            self._provider = user_input[CONF_PROVIDER]
-            return await self.async_step_configure()
+            # Combine the user’s multi‑field instructions exactly as before
+            affect = user_input.get("affect_personality", "")
+            tone = user_input.get("tone", "")
+            pron = user_input.get("pronunciation", "")
+            pause = user_input.get("pause", "")
+            emo = user_input.get("emotion", "")
 
-        # Show provider selection form
+            parts = []
+            if affect:
+                parts.append(f"Affect/personality: {affect}")
+            if tone:
+                parts.append(f"Tone: {tone}")
+            if pron:
+                parts.append(f"Pronunciation: {pron}")
+            if pause:
+                parts.append(f"Pause: {pause}")
+            if emo:
+                parts.append(f"Emotion: {emo}")
+
+            user_input[CONF_INSTRUCTIONS] = "\n".join(parts)
+
+            # Build data + options dicts
+            api_key = user_input[CONF_API_KEY].strip()
+            data = {CONF_API_KEY: api_key}
+            options = {
+                CONF_VOICE: user_input.get(CONF_VOICE, DEFAULT_VOICE),
+                CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
+                CONF_INSTRUCTIONS: user_input.get(CONF_INSTRUCTIONS, ""),
+                CONF_MODEL: user_input.get(CONF_MODEL, DEFAULT_MODEL),
+                CONF_AUDIO_OUTPUT: user_input.get(CONF_AUDIO_OUTPUT, DEFAULT_AUDIO_OUTPUT),
+                CONF_STREAM_FORMAT: user_input.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT),
+                CONF_PLAYBACK_SPEED: float(
+                    user_input.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED)
+                ),
+                "affect_personality": affect,
+                "tone": tone,
+                "pronunciation": pron,
+                "pause": pause,
+                "emotion": emo,
+            }
+
+            _LOGGER.debug("Creating entry with options: %s", options)
+            return self.async_create_entry(
+                title="OpenAI GPT‑4o TTS", data=data, options=options
+            )
+
+        # Show the setup form
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_PROVIDER, default=DEFAULT_PROVIDER): vol.In(
-                    {PROVIDER_OPENAI: "OpenAI", PROVIDER_AZURE: "Azure AI Foundry"}
+                vol.Required(CONF_API_KEY): str,
+                vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(
+                    OPENAI_TTS_VOICES
+                ),
+                vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(
+                    SUPPORTED_LANGUAGES
+                ),
+                vol.Optional(CONF_MODEL, default=DEFAULT_MODEL): vol.In(
+                    OPENAI_TTS_MODELS
+                ),
+                vol.Optional(CONF_AUDIO_OUTPUT, default=DEFAULT_AUDIO_OUTPUT): vol.In(
+                    OPENAI_AUDIO_FORMATS
+                ),
+                vol.Optional(CONF_STREAM_FORMAT, default=DEFAULT_STREAM_FORMAT): vol.In(
+                    OPENAI_STREAM_FORMATS
+                ),
+                vol.Optional(
+                    CONF_PLAYBACK_SPEED, default=DEFAULT_PLAYBACK_SPEED
+                ): vol.All(vol.Coerce(float), vol.Range(min=0.25, max=4.0)),
+                vol.Optional("affect_personality", default=DEFAULT_AFFECT): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("tone", default=DEFAULT_TONE): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("pronunciation", default=DEFAULT_PRONUNCIATION): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("pause", default=DEFAULT_PAUSE): vol.All(
+                    str, vol.Length(min=5, max=500)
+                ),
+                vol.Optional("emotion", default=DEFAULT_EMOTION): vol.All(
+                    str, vol.Length(min=5, max=500)
                 ),
             }
         )
@@ -74,139 +136,12 @@ class OpenAIGPT4oConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=data_schema, errors=errors
         )
 
-    async def async_step_configure(self, user_input=None):
-        """Handle provider-specific configuration (unified for both OpenAI and Azure)."""
-        errors = {}
-
-        if user_input is not None:
-            # Validate Azure endpoint if Azure provider
-            if self._provider == PROVIDER_AZURE:
-                azure_endpoint = user_input.get(CONF_AZURE_ENDPOINT, "").strip()
-                if not azure_endpoint:
-                    errors["azure_endpoint"] = "Azure endpoint URL is required"
-                elif not azure_endpoint.startswith("https://"):
-                    errors["azure_endpoint"] = "Azure endpoint must start with https://"
-                
-                if errors:
-                    # Re-show form with errors
-                    pass
-                else:
-                    return await self._create_entry(user_input, self._provider, azure_endpoint)
-            else:
-                # OpenAI - no additional validation needed
-                return await self._create_entry(user_input, self._provider)
-
-        # Build schema dynamically based on provider
-        schema_fields = {}
-        
-        # Add provider-specific fields first
-        if self._provider == PROVIDER_AZURE:
-            schema_fields[vol.Required(CONF_AZURE_ENDPOINT)] = str
-            schema_fields[vol.Required(CONF_API_KEY)] = str
-        else:
-            schema_fields[vol.Required(CONF_API_KEY)] = str
-        
-        # Add common fields
-        schema_fields.update({
-            vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): vol.In(OPENAI_TTS_VOICES),
-            vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(SUPPORTED_LANGUAGES),
-            vol.Optional(CONF_MODEL, default=DEFAULT_MODEL): vol.In(OPENAI_TTS_MODELS),
-            vol.Optional(CONF_AUDIO_OUTPUT, default=DEFAULT_AUDIO_OUTPUT): vol.In(OPENAI_AUDIO_FORMATS),
-            vol.Optional(CONF_STREAM_FORMAT, default=DEFAULT_STREAM_FORMAT): vol.In(OPENAI_STREAM_FORMATS),
-            vol.Optional(CONF_PLAYBACK_SPEED, default=DEFAULT_PLAYBACK_SPEED): vol.All(
-                vol.Coerce(float), vol.Range(min=0.25, max=4.0)
-            ),
-            vol.Optional(CONF_VOLUME_GAIN, default=DEFAULT_VOLUME_GAIN): vol.All(
-                vol.Coerce(float), vol.Range(min=VOLUME_GAIN_MIN, max=VOLUME_GAIN_MAX)
-            ),
-            vol.Optional("affect_personality", default=DEFAULT_AFFECT): vol.All(
-                str, vol.Length(min=5, max=500)
-            ),
-            vol.Optional("tone", default=DEFAULT_TONE): vol.All(
-                str, vol.Length(min=5, max=500)
-            ),
-            vol.Optional("pronunciation", default=DEFAULT_PRONUNCIATION): vol.All(
-                str, vol.Length(min=5, max=500)
-            ),
-            vol.Optional("pause", default=DEFAULT_PAUSE): vol.All(
-                str, vol.Length(min=5, max=500)
-            ),
-            vol.Optional("emotion", default=DEFAULT_EMOTION): vol.All(
-                str, vol.Length(min=5, max=500)
-            ),
-        })
-
-        data_schema = vol.Schema(schema_fields)
-
-        return self.async_show_form(
-            step_id="configure", data_schema=data_schema, errors=errors
-        )
-
-    async def _create_entry(self, user_input, provider, azure_endpoint=None):
-        """Create the config entry with the provided data."""
-        # Combine the user's multi‑field instructions
-        affect = user_input.get("affect_personality", "")
-        tone = user_input.get("tone", "")
-        pron = user_input.get("pronunciation", "")
-        pause = user_input.get("pause", "")
-        emo = user_input.get("emotion", "")
-
-        parts = []
-        if affect:
-            parts.append(f"Affect/personality: {affect}")
-        if tone:
-            parts.append(f"Tone: {tone}")
-        if pron:
-            parts.append(f"Pronunciation: {pron}")
-        if pause:
-            parts.append(f"Pause: {pause}")
-        if emo:
-            parts.append(f"Emotion: {emo}")
-
-        user_input[CONF_INSTRUCTIONS] = "\n".join(parts)
-
-        # Build data + options dicts
-        api_key = user_input[CONF_API_KEY].strip()
-        data = {
-            CONF_API_KEY: api_key,
-            CONF_PROVIDER: provider,
-        }
-        
-        # Add Azure endpoint to data if Azure provider
-        if provider == PROVIDER_AZURE and azure_endpoint:
-            data[CONF_AZURE_ENDPOINT] = azure_endpoint
-            
-        options = {
-            CONF_VOICE: user_input.get(CONF_VOICE, DEFAULT_VOICE),
-            CONF_LANGUAGE: user_input.get(CONF_LANGUAGE, DEFAULT_LANGUAGE),
-            CONF_INSTRUCTIONS: user_input.get(CONF_INSTRUCTIONS, ""),
-            CONF_MODEL: user_input.get(CONF_MODEL, DEFAULT_MODEL),
-            CONF_AUDIO_OUTPUT: user_input.get(CONF_AUDIO_OUTPUT, DEFAULT_AUDIO_OUTPUT),
-            CONF_STREAM_FORMAT: user_input.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT),
-            CONF_PLAYBACK_SPEED: float(
-                user_input.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED)
-            ),
-            CONF_VOLUME_GAIN: float(
-                user_input.get(CONF_VOLUME_GAIN, DEFAULT_VOLUME_GAIN)
-            ),
-            "affect_personality": affect,
-            "tone": tone,
-            "pronunciation": pron,
-            "pause": pause,
-            "emotion": emo,
-        }
-
-        _LOGGER.debug("Creating entry with options: %s", options)
-        title = "Azure OpenAI GPT-4o TTS" if provider == PROVIDER_AZURE else "OpenAI GPT-4o TTS"
-        return self.async_create_entry(
-            title=title, data=data, options=options
-        )
-
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Allow the user to re‑configure later."""
         return OpenAIGPT4oOptionsFlowHandler(config_entry)
+
 
 class OpenAIGPT4oOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle editing existing TTS settings."""
@@ -245,13 +180,6 @@ class OpenAIGPT4oOptionsFlowHandler(config_entries.OptionsFlow):
                     default=existing.get(CONF_PLAYBACK_SPEED, DEFAULT_PLAYBACK_SPEED),
                 ): vol.All(vol.Coerce(float), vol.Range(min=0.25, max=4.0)),
                 vol.Optional(
-                    CONF_VOLUME_GAIN,
-                    default=existing.get(CONF_VOLUME_GAIN, DEFAULT_VOLUME_GAIN),
-                ): vol.All(
-                    vol.Coerce(float),
-                    vol.Range(min=VOLUME_GAIN_MIN, max=VOLUME_GAIN_MAX),
-                ),
-                vol.Optional(
                     "affect_personality",
                     default=existing.get("affect_personality", DEFAULT_AFFECT),
                 ): vol.All(str, vol.Length(min=5, max=500)),
@@ -272,3 +200,4 @@ class OpenAIGPT4oOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
         return self.async_show_form(step_id="init", data_schema=data_schema)
+

--- a/custom_components/openai_gpt4o_tts/const.py
+++ b/custom_components/openai_gpt4o_tts/const.py
@@ -5,8 +5,6 @@ PLATFORMS = ["tts"]
 
 # Configuration keys
 CONF_API_KEY = "api_key"
-CONF_PROVIDER = "provider"
-CONF_AZURE_ENDPOINT = "azure_endpoint"
 CONF_VOICE = "voice"
 CONF_INSTRUCTIONS = "instructions"
 CONF_LANGUAGE = "language"
@@ -14,25 +12,14 @@ CONF_PLAYBACK_SPEED = "playback_speed"
 CONF_MODEL = "model"
 CONF_AUDIO_OUTPUT = "audio_output"
 CONF_STREAM_FORMAT = "stream_format"
-CONF_VOLUME_GAIN = "volume_gain"
-
-# Provider options
-PROVIDER_OPENAI = "openai"
-PROVIDER_AZURE = "azure"
 
 # Default settings
-DEFAULT_PROVIDER = PROVIDER_OPENAI
 DEFAULT_VOICE = "sage"
 DEFAULT_LANGUAGE = "en"
 DEFAULT_PLAYBACK_SPEED = 1.0
 DEFAULT_MODEL = "gpt-4o-mini-tts"
 DEFAULT_AUDIO_OUTPUT = "mp3"
 DEFAULT_STREAM_FORMAT = "audio"
-DEFAULT_VOLUME_GAIN = 1.0
-
-# Safe volume gain multiplier range (protects listeners and clipping)
-VOLUME_GAIN_MIN = 0.1
-VOLUME_GAIN_MAX = 3.0
 
 # Default multi-field instruction settings
 DEFAULT_AFFECT = (

--- a/custom_components/openai_gpt4o_tts/gpt4o.py
+++ b/custom_components/openai_gpt4o_tts/gpt4o.py
@@ -1,40 +1,25 @@
 """Client for OpenAI GPT-4o Mini TTS."""
 
 import asyncio
-import audioop
 import base64
 import binascii
-import contextlib
-import io
 import json
 import logging
-import math
 import re
-import wave
 from aiohttp import ClientError, ClientResponse, ClientSession, ClientTimeout
-from typing import Optional
 
 from .const import (
-    CONF_PROVIDER,
-    CONF_AZURE_ENDPOINT,
     CONF_INSTRUCTIONS,
     CONF_PLAYBACK_SPEED,
     CONF_VOICE,
     CONF_MODEL,
     CONF_AUDIO_OUTPUT,
     CONF_STREAM_FORMAT,
-    PROVIDER_OPENAI,
-    PROVIDER_AZURE,
-    DEFAULT_PROVIDER,
     DEFAULT_PLAYBACK_SPEED,
     DEFAULT_VOICE,
     DEFAULT_MODEL,
     DEFAULT_AUDIO_OUTPUT,
     DEFAULT_STREAM_FORMAT,
-    CONF_VOLUME_GAIN,
-    DEFAULT_VOLUME_GAIN,
-    VOLUME_GAIN_MIN,
-    VOLUME_GAIN_MAX,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,51 +35,10 @@ OPENAI_TTS_ENDPOINT = "https://api.openai.com/v1/audio/speech"
 # character set and require a reasonable length to avoid false positives.
 _API_KEY_RE = re.compile(r"sk-[A-Za-z0-9-]{16,}")
 
-# Allow-list of characters that appear in base64 payloads so we can
-# differentiate real binary audio (which often contains NULL bytes) from a
-# JSON/base64 encoded string. This guards against feeding ffmpeg invalid data
-# (OWASP A5:2021 – Security Misconfiguration).
-_BASE64_BYTES_RE = re.compile(rb"^[A-Za-z0-9+/=\r\n]+$")
-
-# Maximum amount of buffered SSE text we will accumulate before resetting to
-# avoid unbounded growth if the provider misbehaves (OWASP A7:2021 –
-# Identification and Authentication Failures -> resource exhaustion).
-_MAX_SSE_BUFFER_BYTES = 1_000_000
-
-try:  # pragma: no cover - optional dependency
-    from pydub import AudioSegment
-except ImportError:  # pragma: no cover - optional dependency
-    AudioSegment = None
-
 
 def _mask_api_keys(text: str) -> str:
     """Return ``text`` with API keys masked."""
     return _API_KEY_RE.sub("sk-***", text)
-
-
-def _maybe_decode_base64_bytes(data: bytes) -> Optional[bytes]:
-    """Return decoded bytes when ``data`` looks like base64, else ``None``."""
-
-    if not data:
-        return None
-
-    sample = data.strip()
-    if not sample or len(sample) < 8:  # too small to be meaningful audio
-        return None
-
-    if not _BASE64_BYTES_RE.fullmatch(sample):
-        return None
-
-    try:
-        decoded = base64.b64decode(sample, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-
-    # Guard against decoding plain ASCII speech which would expand in size.
-    if not decoded or len(decoded) >= len(sample):
-        return None
-
-    return decoded
 
 
 async def _log_api_error(resp: ClientResponse) -> None:
@@ -115,10 +59,8 @@ class GPT4oClient:
         self.hass = hass
         self.entry = entry
 
-        # Get provider and API key
-        self._provider = entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER)
+        # Always set your API key
         self._api_key = entry.data["api_key"]
-        self._azure_endpoint = entry.data.get(CONF_AZURE_ENDPOINT, "")
 
         # Pull default voice/instructions from options first, then legacy data
         opts = getattr(entry, "options", {}) or {}
@@ -141,28 +83,6 @@ class GPT4oClient:
         self._stream_format = opts.get(
             CONF_STREAM_FORMAT, entry.data.get(CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT)
         )
-        raw_gain = opts.get(
-            CONF_VOLUME_GAIN, entry.data.get(CONF_VOLUME_GAIN, DEFAULT_VOLUME_GAIN)
-        )
-        self._volume_gain = self._sanitize_volume_gain(raw_gain, log_on_change=False)
-
-    def _get_endpoint(self) -> str:
-        """Return the appropriate API endpoint based on provider."""
-        if self._provider == PROVIDER_AZURE:
-            return self._azure_endpoint
-        return OPENAI_TTS_ENDPOINT
-
-    def _get_headers(self) -> dict:
-        """Return the appropriate headers based on provider."""
-        if self._provider == PROVIDER_AZURE:
-            return {
-                "api-key": self._api_key,
-                "Content-Type": "application/json",
-            }
-        return {
-            "Authorization": f"Bearer {self._api_key}",
-            "Content-Type": "application/json",
-        }
 
     @property
     def stream_format(self) -> str:
@@ -170,239 +90,47 @@ class GPT4oClient:
         return self._stream_format
 
     async def _iter_sse_audio(self, resp: ClientResponse):
-        """Yield audio bytes from an SSE response with robust framing."""
-
-        def _flush_event(payload: str) -> Optional[dict]:
-            data = payload.strip()
-            if not data:
-                return None
-            if data == "[DONE]":
-                return {"type": "speech.audio.done"}
-            try:
-                return json.loads(data)
-            except json.JSONDecodeError:
-                sanitized = _mask_api_keys(data[:128])
-                _LOGGER.debug("Discarding invalid SSE payload prefix: %s", sanitized)
-                return None
-
+        """Yield audio bytes from an SSE response."""
         buffer = ""
-        data_lines: list[str] = []
-
-        async for raw in resp.content.iter_chunked(1024):
-            if not raw:
-                continue
-            try:
-                chunk = raw.decode("utf-8")
-            except UnicodeDecodeError:
-                _LOGGER.warning("Non UTF-8 data in SSE stream; dropping chunk")
-                continue
-
-            buffer += chunk
-            if len(buffer) > _MAX_SSE_BUFFER_BYTES:
-                _LOGGER.warning(
-                    "SSE buffer exceeded %s bytes; resetting to avoid exhaustion",
-                    _MAX_SSE_BUFFER_BYTES,
-                )
+        async for raw in resp.content:
+            line = raw.decode("utf-8")
+            if line.startswith("data:"):
+                data_part = line[5:].strip()
+                if data_part == "[DONE]":
+                    break
+                buffer += data_part
+            elif line.strip() == "":
+                if not buffer:
+                    continue
+                try:
+                    event = json.loads(buffer)
+                except json.JSONDecodeError:
+                    buffer = ""
+                    continue
                 buffer = ""
-                data_lines.clear()
-                continue
-
-            while "\n" in buffer:
-                line, buffer = buffer.split("\n", 1)
-                line = line.rstrip("\r")
-
-                if not line:
-                    if not data_lines:
-                        continue
-                    event = _flush_event("\n".join(data_lines))
-                    data_lines.clear()
-                    if not event:
-                        continue
-                    event_type = event.get("type")
-                    if event_type == "speech.audio.delta":
-                        audio_b64 = event.get("audio", "")
-                        if isinstance(audio_b64, str) and audio_b64:
-                            try:
-                                yield base64.b64decode(audio_b64, validate=True)
-                            except (binascii.Error, ValueError):
-                                _LOGGER.warning("Invalid audio chunk in SSE stream")
-                    if event_type == "speech.audio.done":
-                        return
-                    continue
-
-                if line.startswith(":"):
-                    continue  # comment/heartbeat per SSE spec
-
-                if line.startswith("data:"):
-                    data_line = line[5:]
-                    if data_line.startswith(" "):
-                        data_line = data_line[1:]
-                    data_lines.append(data_line)
-                    continue
-
-                # Ignore other SSE fields we do not rely on for now
-
-        if data_lines:
-            event = _flush_event("\n".join(data_lines))
-            if not event:
-                return
-            if event.get("type") == "speech.audio.delta":
-                audio_b64 = event.get("audio", "")
-                if isinstance(audio_b64, str) and audio_b64:
-                    try:
-                        yield base64.b64decode(audio_b64, validate=True)
-                    except (binascii.Error, ValueError):
-                        _LOGGER.warning("Invalid audio chunk in trailing SSE payload")
-            if event.get("type") == "speech.audio.done":
-                return
+                if event.get("type") == "speech.audio.delta":
+                    audio_b64 = event.get("audio", "")
+                    if audio_b64:
+                        try:
+                            yield base64.b64decode(audio_b64)
+                        except (binascii.Error, ValueError):
+                            _LOGGER.warning("Invalid audio chunk in SSE stream")
+                elif event.get("type") == "speech.audio.done":
+                    break
+        if buffer:
+            try:
+                event = json.loads(buffer)
+                if event.get("type") == "speech.audio.delta":
+                    audio_b64 = event.get("audio", "")
+                    if audio_b64:
+                        yield base64.b64decode(audio_b64)
+            except json.JSONDecodeError:
+                pass
 
     @property
     def audio_output(self) -> str:
         """Return the default audio output format."""
         return self._audio_output
-
-    @property
-    def volume_gain(self) -> float:
-        """Return the configured default volume gain multiplier."""
-        return self._volume_gain
-
-    def _sanitize_volume_gain(self, value: Optional[float], *, log_on_change: bool = True) -> float:
-        """Normalize a user-provided gain into the supported safe range."""
-        try:
-            gain = float(value)
-        except (TypeError, ValueError):
-            if log_on_change:
-                _LOGGER.warning(
-                    "Invalid volume gain %s; using %.2f", value, DEFAULT_VOLUME_GAIN
-                )
-            return DEFAULT_VOLUME_GAIN
-
-        if not math.isfinite(gain):
-            if log_on_change:
-                _LOGGER.warning(
-                    "Non-finite volume gain %s; using %.2f", value, DEFAULT_VOLUME_GAIN
-                )
-            return DEFAULT_VOLUME_GAIN
-
-        clamped = max(VOLUME_GAIN_MIN, min(gain, VOLUME_GAIN_MAX))
-        if log_on_change and not math.isclose(clamped, gain, rel_tol=1e-3, abs_tol=1e-3):
-            _LOGGER.warning(
-                "Volume gain %.2f adjusted into safe range %.1f–%.1f", gain, VOLUME_GAIN_MIN, VOLUME_GAIN_MAX
-            )
-        return clamped
-
-    def _resolve_volume_gain(self, options: Optional[dict]) -> float:
-        """Return gain override if provided, otherwise default."""
-        if options and CONF_VOLUME_GAIN in options:
-            return self._sanitize_volume_gain(options.get(CONF_VOLUME_GAIN))
-        return self._volume_gain
-
-    def _scale_pcm_frames(self, frames: bytes, sample_width: int, gain: float) -> Optional[bytes]:
-        """Apply gain to PCM frames with saturation handling."""
-        if sample_width not in (1, 2, 3, 4):
-            _LOGGER.warning("Unsupported PCM sample width %s; skipping gain", sample_width)
-            return None
-        try:
-            return audioop.mul(frames, sample_width, gain)
-        except Exception as err:  # pragma: no cover - defensive
-            _LOGGER.warning("Failed to scale PCM audio safely: %s", err)
-            return None
-
-    def _apply_volume_gain(self, audio_format: str, audio_bytes: bytes, gain: float) -> bytes:
-        """Scale audio bytes according to ``gain`` while respecting safe bounds."""
-        if not audio_bytes:
-            return audio_bytes
-
-        safe_gain = self._sanitize_volume_gain(gain)
-        if math.isclose(safe_gain, 1.0, rel_tol=1e-3, abs_tol=1e-3):
-            return audio_bytes
-
-        fmt = (audio_format or "").lower()
-
-        if fmt in {"wav", "wave"}:
-            try:
-                with contextlib.closing(wave.open(io.BytesIO(audio_bytes), "rb")) as wav_in:
-                    params = wav_in.getparams()
-                    frames = wav_in.readframes(params.nframes)
-            except (wave.Error, EOFError, OSError) as err:
-                _LOGGER.warning("Unable to read WAV audio for gain adjustment: %s", err)
-                return audio_bytes
-            scaled = self._scale_pcm_frames(frames, params.sampwidth, safe_gain)
-            if scaled is None:
-                return audio_bytes
-            out_buf = io.BytesIO()
-            with contextlib.closing(wave.open(out_buf, "wb")) as wav_out:
-                wav_out.setparams(params)
-                wav_out.writeframes(scaled)
-            return out_buf.getvalue()
-
-        if fmt == "pcm":
-            scaled = self._scale_pcm_frames(audio_bytes, 2, safe_gain)
-            if scaled is None:
-                _LOGGER.warning(
-                    "PCM gain adjustment skipped; ensure 16-bit PCM when requesting scaling"
-                )
-                return audio_bytes
-            return scaled
-
-        if AudioSegment is not None and fmt:
-            try:
-                segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format=fmt)
-                delta_db = 20 * math.log10(safe_gain)
-                boosted = segment.apply_gain(delta_db)
-                export_buf = io.BytesIO()
-                boosted.export(export_buf, format=fmt)
-                return export_buf.getvalue()
-            except Exception as err:  # pragma: no cover - codec/ffmpeg issues
-                _LOGGER.warning(
-                    "Unable to apply volume gain to %s audio: %s", fmt, err
-                )
-                return audio_bytes
-
-        if fmt not in {"", "wav", "wave", "pcm"} and AudioSegment is None:
-            _LOGGER.warning(
-                "Install pydub and FFmpeg to enable safe volume scaling for %s audio", fmt
-            )
-
-        return audio_bytes
-
-    def _extract_audio_bytes(self, audio_format: str, audio_bytes: bytes) -> bytes:
-        """Return binary audio, decoding base64/JSON payloads when necessary."""
-
-        if not audio_bytes:
-            return audio_bytes
-
-        fmt = (audio_format or "").lower()
-
-        # Some providers wrap PCM data in base64; decode it safely before
-        # handing to Home Assistant to avoid ffmpeg failures downstream.
-        if fmt == "pcm":
-            decoded = _maybe_decode_base64_bytes(audio_bytes)
-            if decoded is not None:
-                return decoded
-
-        # Defensive: occasionally Azure responses may contain JSON with a
-        # base64 encoded payload. Detect and decode so we only ever return
-        # binary audio.
-        try:
-            text_payload = audio_bytes.decode("utf-8")
-        except UnicodeDecodeError:
-            return audio_bytes
-
-        try:
-            parsed = json.loads(text_payload)
-        except json.JSONDecodeError:
-            return audio_bytes
-
-        if isinstance(parsed, dict):
-            for key in ("audio", "data", "value"):
-                candidate = parsed.get(key)
-                if isinstance(candidate, str):
-                    decoded = _maybe_decode_base64_bytes(candidate.encode("utf-8"))
-                    if decoded is not None:
-                        return decoded
-
-        return audio_bytes
 
     async def iter_tts_audio(self, text: str, options: dict | None = None):
         """Asynchronously yield audio chunks from the API."""
@@ -415,8 +143,10 @@ class GPT4oClient:
         model = options.get(CONF_MODEL, self._model)
         stream_format = options.get(CONF_STREAM_FORMAT, self._stream_format)
 
-        headers = self._get_headers()
-        endpoint = self._get_endpoint()
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
         payload = {
             "model": model,
             "voice": voice,
@@ -430,7 +160,7 @@ class GPT4oClient:
         timeout = ClientTimeout(total=REQUEST_TIMEOUT)
         async with ClientSession(timeout=timeout) as session:
             async with session.post(
-                endpoint,
+                OPENAI_TTS_ENDPOINT,
                 headers=headers,
                 json=payload,
             ) as resp:
@@ -447,18 +177,12 @@ class GPT4oClient:
 
     async def get_tts_audio(self, text: str, options: dict | None = None):
         """Generate TTS audio from GPT-4o using direct HTTP calls."""
-        if options is None:
-            options = {}
-
         try:
             audio_chunks = [chunk async for chunk in self.iter_tts_audio(text, options)]
             if not audio_chunks:
                 return None, None
-            audio_format = options.get("audio_output", self._audio_output)
-            gain = self._resolve_volume_gain(options)
-            joined = b"".join(audio_chunks)
-            audio_bytes = self._extract_audio_bytes(audio_format, joined)
-            return audio_format, self._apply_volume_gain(audio_format, audio_bytes, gain)
+            audio_format = options.get("audio_output", self._audio_output) if options else self._audio_output
+            return audio_format, b"".join(audio_chunks)
         except asyncio.TimeoutError:
             _LOGGER.error(
                 "GPT-4o TTS request timed out after %s seconds", REQUEST_TIMEOUT

--- a/custom_components/openai_gpt4o_tts/manifest.json
+++ b/custom_components/openai_gpt4o_tts/manifest.json
@@ -1,15 +1,15 @@
 {
-    "domain": "openai_gpt4o_tts",
-    "name": "OpenAI GPT-4o Mini TTS",
-    "version": "1.0.12",
-    "author": "wifiuk",
-    "documentation": "https://github.com/wifiuk/OpenAI-GPT-4o-Mini-TTS-Home-Assistant-Integration",
-    "requirements": ["aiohttp>=3.9.3"],
-    "codeowners": [
-      "@wifiuk"
-    ],
-    "iot_class": "cloud_polling",
-    "config_flow": true
-  }
-  
-
+  "domain": "openai_gpt4o_tts",
+  "name": "OpenAI GPT-4o Mini TTS",
+  "version": "1.0.9",
+  "author": "wifiuk",
+  "documentation": "https://github.com/wifiuk/OpenAI-GPT-4o-Mini-TTS-Home-Assistant-Integration",
+  "requirements": [
+    "aiohttp>=3.9.3"
+  ],
+  "codeowners": [
+    "@wifiuk"
+  ],
+  "iot_class": "cloud_polling",
+  "config_flow": true
+}

--- a/custom_components/openai_gpt4o_tts/tts.py
+++ b/custom_components/openai_gpt4o_tts/tts.py
@@ -17,16 +17,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     DOMAIN,
-    CONF_PROVIDER,
-    PROVIDER_AZURE,
-    DEFAULT_PROVIDER,
     OPENAI_TTS_VOICES,
     SUPPORTED_LANGUAGES,
     DEFAULT_LANGUAGE,
     CONF_PLAYBACK_SPEED,
     CONF_MODEL,
     CONF_STREAM_FORMAT,
-    CONF_VOLUME_GAIN,
 )
 from .gpt4o import GPT4oClient
 
@@ -49,8 +45,7 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
     def __init__(self, config_entry: ConfigEntry, client: GPT4oClient) -> None:
         self._config_entry = config_entry
         self._client = client
-        provider = config_entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER)
-        self._name = "Azure OpenAI GPT-4o Mini TTS" if provider == PROVIDER_AZURE else "OpenAI GPT-4o Mini TTS"
+        self._name = "OpenAI GPT‑4o Mini TTS"
         self._attr_unique_id = f"{config_entry.entry_id}-tts"
 
     @property
@@ -71,10 +66,7 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
     @property
     def default_options(self) -> dict:
         """Default TTS options, e.g. mp3."""
-        return {
-            ATTR_AUDIO_OUTPUT: self._client.audio_output,
-            CONF_VOLUME_GAIN: self._client.volume_gain,
-        }
+        return {ATTR_AUDIO_OUTPUT: self._client.audio_output}
 
     @property
     def supported_options(self) -> list[str]:
@@ -86,7 +78,6 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
             CONF_PLAYBACK_SPEED,
             CONF_MODEL,
             CONF_STREAM_FORMAT,
-            CONF_VOLUME_GAIN,
         ]
 
     async def async_get_tts_audio(
@@ -131,3 +122,4 @@ class OpenAIGPT4oTTSProvider(TextToSpeechEntity):
     def extra_state_attributes(self) -> dict:
         """Optional: expose provider name or debug info."""
         return {"provider": self._name}
+


### PR DESCRIPTION
## Summary
- replace `custom_components/openai_gpt4o_tts` with the files from the v1.0.9 GitHub release archive
- set the integration manifest version metadata to 1.0.9 so Home Assistant recognises the older build

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_68e3d45e3d248331a5729608819a6aa4